### PR TITLE
Update to use upstream optimizations and remove LRU

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,7 +668,7 @@ dependencies = [
 
 [[package]]
 name = "geoip-api"
-version = "0.7.1"
+version = "0.1.1"
 dependencies = [
  "actix-cors 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-rt 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -679,7 +679,7 @@ dependencies = [
  "flate2 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru_time_cache 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "maxminddb 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "maxminddb 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "md5 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -940,7 +940,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "maxminddb"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1976,7 +1976,7 @@ dependencies = [
 "checksum lru_time_cache 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "adb241df5c4caeb888755363fc95f8a896618dc0d435e9e775f7930cb099beab"
 "checksum match_cfg 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
-"checksum maxminddb 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9412a854bf1355d1ff92ef6ffe557dcc4a866e20cdffc7d3fc082174dba7436e"
+"checksum maxminddb 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9d4f312870f536f2f87d6afe80570c3df890bd9b9985dfadd3c2e9bba183d80"
 "checksum md5 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 "checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 "checksum mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "geoip-api"
 description = "geoip-api provides geographical information about the specified IP address with an auto-updating database"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Matthew Wynn <matthew@matthewwynn.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -17,7 +17,6 @@ chrono = "0.4"
 env_logger = "0.7"
 flate2 = "1.0"
 log = "0.4"
-maxminddb = { version = "0.13.0" }
 md5 = "0.7"
 prometheus = "0.8"
 serde = "1"
@@ -26,7 +25,6 @@ serde_json = "1"
 structopt = "0.3"
 thiserror = "1.0"
 tokio = "0.2"
-lru_time_cache = "0.10"
 
 [dependencies.actix-web]
 version = "2"
@@ -36,3 +34,10 @@ default_features = false
 version = "0.10"
 default_features = false
 features = ["rustls-tls"]
+
+[dependencies.maxminddb]
+version = "0.14"
+# This feature does not validate that strings in the maxminddb are valid utf-8
+# However, we do verify the checksum of the maxminddb and do not use the strings
+# in a super sensitive way
+features = ["unsafe-str-decode"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,5 @@ COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifica
 COPY --from=build /home/rust/src/target/x86_64-unknown-linux-musl/release/geoip-api /
 USER 1000
 ENV RUST_LOG WARN
-CMD ["/geoip-api"]
 EXPOSE 3000/tcp
+CMD ["/geoip-api"]


### PR DESCRIPTION
The LRU adds basically nothing in such a distributed environment, and adds an extra mutex.

using `wrk -t 8 -c 60` this takes me from 50k-150k rps on origin/master (depending on the efficiency of the LRU) to 230k on my laptop.